### PR TITLE
feat: add clubhouse story ids to commits and branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Here are the options you can set in your `.cz-config.js`:
 * **upperCaseSubject**: { boolean, default false }: Capitalizes first subject letter if set to `true`
 * **askForBreakingChangeFirst**: { boolean, default false }: It asks for breaking change as first question when set to `true`
 * **isClubhouseIDRequired**: {boolean, default false}: Will ask to link stories to commits if set to `true`
+* **clubhouseSkipTypes**: {Array of string}: The commit types that should skip adding clubhouse stories
 * **clubhouseVerbs**: {Array of string}: The verbs used to move commits through Clubhouse workflows. Example: ["start", "finish"]
 
 ## Related tools

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Here are the options you can set in your `.cz-config.js`:
 * **breaklineChar**: {string, default '|'}: It gets replaced with \n to create the breakline in your commit message. This is supported for fields `body` and `footer` at the moment.
 * **upperCaseSubject**: { boolean, default false }: Capitalizes first subject letter if set to `true`
 * **askForBreakingChangeFirst**: { boolean, default false }: It asks for breaking change as first question when set to `true`
+* **isClubhouseIDRequired**: {boolean, default false}: Will ask to link stories to commits if set to `true`
+* **clubhouseVerbs**: {Array of string}: The verbs used to move commits through Clubhouse workflows. Example: ["start", "finish"]
 
 ## Related tools
 - (https://github.com/commitizen/cz-cli)

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -60,7 +60,7 @@ const addClubhouse = answers => {
 
       if (answers.clubhouseAddVerb) formatted.push(`[${commitVerb}ch${_.trim(id)}]`);
 
-      if (!answers.clubhouseAddVerb && !answers.clubhouseLinkBranch) formatted.push(`[ch ${_.trim(id)}]`);
+      if (!answers.clubhouseAddVerb && !answers.clubhouseLinkBranch) formatted.push(`[ch${_.trim(id)}]`);
 
       return formatted.join(' ');
     })

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -46,6 +46,29 @@ const addFooter = (footer, config) => {
   return `\n\n${footerPrefix} ${addBreaklinesIfNeeded(footer, config.breaklineChar)}`;
 };
 
+const addClubhouse = answers => {
+  const commitVerb = answers.clubhouseVerb ? `${_.trim(answers.clubhouseVerb)} ` : '';
+
+  const result = `\n\nClubhouse Stories:\n${answers.clubhouseStoryID
+    .split(',')
+    .sort()
+    .flatMap(id => {
+      const formatted = [];
+      if (!id) return formatted;
+
+      if (answers.clubhouseLinkBranch) formatted.push(`[branch ch${_.trim(id)}]`);
+
+      if (answers.clubhouseAddVerb) formatted.push(`[${commitVerb}ch${_.trim(id)}]`);
+
+      if (!answers.clubhouseAddVerb && !answers.clubhouseLinkBranch) formatted.push(`[ch ${_.trim(id)}]`);
+
+      return formatted.join(' ');
+    })
+    .join('\n')}`;
+
+  return result;
+};
+
 const escapeSpecialChars = result => {
   // eslint-disable-next-line no-useless-escape
   const specialChars = ['`'];
@@ -88,10 +111,16 @@ module.exports = (answers, config) => {
   if (body) {
     result += `\n\n${body}`;
   }
+
+  if (config.isClubhouseIDRequired) {
+    result += addClubhouse(answers);
+  }
+
   if (breaking) {
     const breakingPrefix = config && config.breakingPrefix ? config.breakingPrefix : 'BREAKING CHANGE:';
     result += `\n\n${breakingPrefix}\n${breaking}`;
   }
+
   if (footer) {
     result += addFooter(footer, config);
   }

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -112,7 +112,7 @@ module.exports = (answers, config) => {
     result += `\n\n${body}`;
   }
 
-  if (config.isClubhouseIDRequired && answers.clubhouseStoryID) {
+  if (config.isClubhouseIDRequired && answers.clubhouseStoryID && answers.clubhouseStoryID !== 'SKIP') {
     result += addClubhouse(answers);
   }
 

--- a/buildCommit.js
+++ b/buildCommit.js
@@ -112,7 +112,7 @@ module.exports = (answers, config) => {
     result += `\n\n${body}`;
   }
 
-  if (config.isClubhouseIDRequired) {
+  if (config.isClubhouseIDRequired && answers.clubhouseStoryID) {
     result += addClubhouse(answers);
   }
 

--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -58,7 +58,8 @@ module.exports = {
     body: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
     breaking: 'List any BREAKING CHANGES (optional):\n',
     footer: 'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
-    clubhouseStoryID: '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\n',
+    clubhouseStoryID:
+      '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\nTo manually override enter "SKIP"\n',
     clubhouseAddVerb: '\nDo you want to add a clubhouse verb to the story?',
     clubhouseLinkBranch: '\nDo you want to link these stories with the current branch?',
     confirmCommit: 'Are you sure you want to proceed with the commit above?',

--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -27,9 +27,11 @@ module.exports = {
   ],
 
   scopes: [{ name: 'accounts' }, { name: 'admin' }, { name: 'exampleScope' }, { name: 'changeMe' }],
+  clubhouseVerbs: [{ name: 'start' }, { name: 'close' }],
 
   allowTicketNumber: false,
   isTicketNumberRequired: false,
+  isClubhouseIDRequired: false,
   ticketNumberPrefix: 'TICKET-',
   ticketNumberRegExp: '\\d{1,5}',
 
@@ -55,6 +57,9 @@ module.exports = {
     body: 'Provide a LONGER description of the change (optional). Use "|" to break new line:\n',
     breaking: 'List any BREAKING CHANGES (optional):\n',
     footer: 'List any ISSUES CLOSED by this change (optional). E.g.: #31, #34:\n',
+    clubhouseStoryID: '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\n',
+    clubhouseAddVerb: '\nDo you want to add a clubhouse verb to the story?',
+    clubhouseLinkBranch: '\nDo you want to link these stories with the current branch?',
     confirmCommit: 'Are you sure you want to proceed with the commit above?',
   },
 

--- a/cz-config-EXAMPLE.js
+++ b/cz-config-EXAMPLE.js
@@ -28,6 +28,7 @@ module.exports = {
 
   scopes: [{ name: 'accounts' }, { name: 'admin' }, { name: 'exampleScope' }, { name: 'changeMe' }],
   clubhouseVerbs: [{ name: 'start' }, { name: 'close' }],
+  clubhouseSkipTypes: ['test'],
 
   allowTicketNumber: false,
   isTicketNumberRequired: false,

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,5 +29,6 @@ declare module 'cz-customizable' {
     footerPrefix?: string;
     subjectLimit?: number;
     isClubhouseIDRequired?: boolean;
+    clubhouseSkipTypes?: string[];
   }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module "cz-customizable" {
+declare module 'cz-customizable' {
   export interface Option {
     name: string;
     value?: string;
@@ -8,14 +8,17 @@ declare module "cz-customizable" {
     scopes?: Option[];
     scopeOverrides?: { [type: string]: Option[] };
     messages?: {
-      type?: string,
-      scope?: string,
-      customScope?: string,
-      subject?: string,
-      body?: string,
-      breaking?: string,
-      footer?: string,
-      confirmCommit?: string,
+      type?: string;
+      scope?: string;
+      customScope?: string;
+      subject?: string;
+      body?: string;
+      breaking?: string;
+      footer?: string;
+      clubhouseStoryID?: string;
+      clubhouseAddVerb?: string;
+      clubhouseLinkBranch?: string;
+      confirmCommit?: string;
     };
     allowCustomScopes?: boolean;
     allowBreakingChanges?: string[];
@@ -25,5 +28,6 @@ declare module "cz-customizable" {
     breakingPrefix?: string;
     footerPrefix?: string;
     subjectLimit?: number;
+    isClubhouseIDRequired?: boolean;
   }
 }

--- a/questions.js
+++ b/questions.js
@@ -179,7 +179,7 @@ module.exports = {
           { key: 'y', name: 'Yes add clubhouse verb', value: true },
           { key: 'n', name: 'DO NOT add clubhouse verb', value: false },
         ],
-        default: 1,
+        default: 0,
         message: messages.clubhouseAddVerb,
         when(answers) {
           return answers.clubhouseStoryID;

--- a/questions.js
+++ b/questions.js
@@ -160,7 +160,10 @@ module.exports = {
         name: 'clubhouseStoryID',
         message: messages.clubhouseStoryID,
         when(answers) {
-          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+          return (
+            // no clubhouse story ids allowed unless specified and the type should not be skipped
+            isNotWip(answers) && !!config.isClubhouseIDRequired && !config.clubhouseSkipTypes.includes(answers.type)
+          );
         },
         validate(value = '') {
           const filterEmpty = value.split(',').filter(id => !!id);
@@ -179,7 +182,7 @@ module.exports = {
         default: 1,
         message: messages.clubhouseAddVerb,
         when(answers) {
-          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+          return answers.clubhouseStoryID;
         },
       },
       {
@@ -190,7 +193,7 @@ module.exports = {
           return config.clubhouseVerbs;
         },
         when(answers) {
-          return answers.clubhouseStoryID && answers.clubhouseAddVerb;
+          return answers.clubhouseAddVerb;
         },
       },
       {
@@ -204,7 +207,7 @@ module.exports = {
         default: 1,
         message: messages.clubhouseLinkBranch,
         when(answers) {
-          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+          return answers.clubhouseStoryID;
         },
       },
       {

--- a/questions.js
+++ b/questions.js
@@ -27,7 +27,13 @@ module.exports = {
 
     messages.type = messages.type || "Select the type of change that you're committing:";
     messages.scope = messages.scope || '\nDenote the SCOPE of this change (optional):';
+    messages.clubhouseVerb = messages.clubhouseVerb || '\nSelect the clubhouse verb for this commit (optional):';
     messages.customScope = messages.customScope || 'Denote the SCOPE of this change:';
+    messages.clubhouseStoryID =
+      messages.clubhouseStoryID || '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\n';
+    messages.clubhouseAddVerb = messages.clubhouseAddVerb || '\nDo you want to add a clubhouse verb to the story?';
+    messages.clubhouseLinkBranch =
+      messages.clubhouseLinkBranch || '\nDo you want to link these stories with the current branch?';
     if (!messages.ticketNumber) {
       if (config.ticketNumberRegExp) {
         messages.ticketNumber =
@@ -148,6 +154,58 @@ module.exports = {
         name: 'footer',
         message: messages.footer,
         when: isNotWip,
+      },
+      {
+        type: 'input',
+        name: 'clubhouseStoryID',
+        message: messages.clubhouseStoryID,
+        when(answers) {
+          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+        },
+        validate(value = '') {
+          const filterEmpty = value.split(',').filter(id => !!id);
+
+          return filterEmpty.length > 0 && filterEmpty.every(id => /^\d+(,{0,1})$/.test(_.trim(id)));
+        },
+      },
+      {
+        type: 'expand',
+        name: 'clubhouseAddVerb',
+        // eslint-disable-next-line prettier/prettier
+        choices: [
+          { key: 'y', name: 'Yes add clubhouse verb', value: true },
+          { key: 'n', name: 'DO NOT add clubhouse verb', value: false },
+        ],
+        default: 1,
+        message: messages.clubhouseAddVerb,
+        when(answers) {
+          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+        },
+      },
+      {
+        type: 'list',
+        name: 'clubhouseVerb',
+        message: messages.clubhouseVerb,
+        choices() {
+          return config.clubhouseVerbs;
+        },
+        when(answers) {
+          return answers.clubhouseStoryID && answers.clubhouseAddVerb;
+        },
+      },
+      {
+        type: 'expand',
+        name: 'clubhouseLinkBranch',
+        // eslint-disable-next-line prettier/prettier
+        choices: [
+          { key: 'y', name: 'Yes link branch', value: true },
+          { key: 'n', name: 'DO NOT link branch', value: false },
+        ],
+        default: 1,
+        message: messages.clubhouseLinkBranch,
+        when(answers) {
+          return isNotWip(answers) && !!config.isClubhouseIDRequired; // no clubhouse story ids allowed unless specified
+        },
       },
       {
         type: 'expand',

--- a/questions.js
+++ b/questions.js
@@ -30,7 +30,8 @@ module.exports = {
     messages.clubhouseVerb = messages.clubhouseVerb || '\nSelect the clubhouse verb for this commit (optional):';
     messages.customScope = messages.customScope || 'Denote the SCOPE of this change:';
     messages.clubhouseStoryID =
-      messages.clubhouseStoryID || '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\n';
+      messages.clubhouseStoryID ||
+      '\nEnter clubhouse story ids separated by commas (REQUIRED). E.g.: 12, 34, 77\nTo manually override enter "SKIP"\n';
     messages.clubhouseAddVerb = messages.clubhouseAddVerb || '\nDo you want to add a clubhouse verb to the story?';
     messages.clubhouseLinkBranch =
       messages.clubhouseLinkBranch || '\nDo you want to link these stories with the current branch?';
@@ -168,7 +169,9 @@ module.exports = {
         validate(value = '') {
           const filterEmpty = value.split(',').filter(id => !!id);
 
-          return filterEmpty.length > 0 && filterEmpty.every(id => /^\d+(,{0,1})$/.test(_.trim(id)));
+          return (
+            value === 'SKIP' || (filterEmpty.length > 0 && filterEmpty.every(id => /^\d+(,{0,1})$/.test(_.trim(id))))
+          );
         },
       },
       {
@@ -182,7 +185,7 @@ module.exports = {
         default: 0,
         message: messages.clubhouseAddVerb,
         when(answers) {
-          return answers.clubhouseStoryID;
+          return answers.clubhouseStoryID && answers.clubhouseStoryID !== 'SKIP';
         },
       },
       {
@@ -207,7 +210,7 @@ module.exports = {
         default: 1,
         message: messages.clubhouseLinkBranch,
         when(answers) {
-          return answers.clubhouseStoryID;
+          return answers.clubhouseStoryID && answers.clubhouseStoryID !== 'SKIP';
         },
       },
       {

--- a/spec/buildCommitSpec.js
+++ b/spec/buildCommitSpec.js
@@ -26,6 +26,55 @@ describe('buildCommit()', () => {
     expect(buildCommit(answers, options)).toEqual('feat(app) this is a new feature');
   });
 
+  describe('with clubhouse', () => {
+    it('link clubhouse stories to commit with no verb', () => {
+      const options = {
+        isClubhouseIDRequired: true,
+      };
+      const clubhouseAnswers = {
+        type: 'feat',
+        subject: 'subject',
+        clubhouseStoryID: '989, 123',
+        clubhouseAddVerb: true,
+      };
+
+      expect(buildCommit(clubhouseAnswers, options)).toEqual('feat: subject\n\nClubhouse Stories:\n[ch123]\n[ch989]');
+    });
+
+    it('link clubhouse stories to commit with verb', () => {
+      const options = {
+        isClubhouseIDRequired: true,
+      };
+      const clubhouseAnswers = {
+        type: 'feat',
+        subject: 'subject',
+        clubhouseStoryID: '989, 123',
+        clubhouseAddVerb: true,
+        clubhouseVerb: 'start',
+      };
+
+      expect(buildCommit(clubhouseAnswers, options)).toEqual(
+        'feat: subject\n\nClubhouse Stories:\n[start ch123]\n[start ch989]'
+      );
+    });
+
+    it('link clubhouse stories to the current branch', () => {
+      const options = {
+        isClubhouseIDRequired: true,
+      };
+      const clubhouseAnswers = {
+        type: 'feat',
+        subject: 'subject',
+        clubhouseStoryID: '989, 123',
+        clubhouseLinkBranch: true,
+      };
+
+      expect(buildCommit(clubhouseAnswers, options)).toEqual(
+        'feat: subject\n\nClubhouse Stories:\n[branch ch123]\n[branch ch989]'
+      );
+    });
+  });
+
   describe('without scope', () => {
     it('subject without scope', () => {
       const answersNoScope = {

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -282,15 +282,27 @@ describe('cz-customizable', () => {
   });
 
   describe('Clubhouse', () => {
-    it('disables clubhouse questions', () => {
+    it('disables clubhouse questions when not required', () => {
       config = {
         types: [{ value: 'feat', name: 'feat: my feat' }],
         isClubhouseIDRequired: false,
       };
 
       expect(getQuestion(9).name).toEqual('clubhouseStoryID');
-      expect(getQuestion(9).when({ type: 'wip', clubhouseStoryID: false })).toEqual(false);
-      expect(getQuestion(9).when({ type: 'wip', clubhouseStoryID: true })).toEqual(false);
+      expect(getQuestion(9).when({ type: 'wip' })).toEqual(false);
+      expect(getQuestion(9).when({ type: 'feat' })).toEqual(false);
+    });
+
+    it('disables clubhouse questions when type is ignored', () => {
+      config = {
+        types: [{ value: 'feat', name: 'feat: my feat' }],
+        isClubhouseIDRequired: true,
+        clubhouseSkipTypes: ['test'],
+      };
+
+      expect(getQuestion(9).name).toEqual('clubhouseStoryID');
+      expect(getQuestion(9).when({ type: 'test' })).toEqual(false);
+      expect(getQuestion(9).when({ type: 'feat' })).toEqual(true);
     });
 
     it('custom message defined', () => {


### PR DESCRIPTION
First, thank you for maintaining this library. It has been really helpful. 

We have a use case that I thought may be of use for others, hence this PR - which allows the user to set [Clubhouse](clubhouse.io) story ids to branches and commits.

If you wish to merge but need anything else done first, don't hesitate to ask.

Squashed:
feat: link clubhouse stories with commits
feat: add clubhouse verbs to commits
feat: link clubhouse story with the current branch(url)