### PR TITLE
fix: support prepared commit message

### DIFF
--- a/questions.js
+++ b/questions.js
@@ -29,7 +29,7 @@ const getPreparedCommit = context => {
       .replace(/[\r\n]$/, '')
       .split(/\r\n|\r|\n/);
     if (preparedCommit) {
-      if (context === 'subject') [ message ] = preparedCommit;
+      if (context === 'subject') [message] = preparedCommit;
       else if (context === 'body' && preparedCommit.length > 1) {
         preparedCommit.shift();
         message = preparedCommit.join('|');

--- a/questions.js
+++ b/questions.js
@@ -1,6 +1,6 @@
+const { existsSync, readFileSync } = require('fs');
 const _ = require('lodash');
 const buildCommit = require('./buildCommit');
-const { existsSync, readFileSync } = require('fs');
 const log = require('./logger');
 
 const isNotWip = answers => answers.type.toLowerCase() !== 'wip';
@@ -29,7 +29,7 @@ const getPreparedCommit = context => {
       .replace(/[\r\n]$/, '')
       .split(/\r\n|\r|\n/);
     if (preparedCommit) {
-      if (context === 'subject') message = preparedCommit[0];
+      if (context === 'subject') [ message ] = preparedCommit;
       else if (context === 'body' && preparedCommit.length > 1) {
         preparedCommit.shift();
         message = preparedCommit.join('|');

--- a/questions.js
+++ b/questions.js
@@ -1,4 +1,4 @@
-const { existsSync, readFileSync } = require('fs');
+const fs = require('fs');
 const _ = require('lodash');
 const buildCommit = require('./buildCommit');
 const log = require('./logger');
@@ -21,14 +21,15 @@ const isValidateTicketNo = (value, config) => {
 
 const getPreparedCommit = context => {
   let message = null;
-  if (existsSync('./.git/COMMIT_EDITMSG')) {
-    let preparedCommit = readFileSync('./.git/COMMIT_EDITMSG', 'utf-8');
+  if (fs.existsSync('./.git/COMMIT_EDITMSG')) {
+    let preparedCommit = fs.readFileSync('./.git/COMMIT_EDITMSG', 'utf-8');
     preparedCommit = preparedCommit
       .replace(/^#.*/gm, '')
       .replace(/^\s*[\r\n]/gm, '')
       .replace(/[\r\n]$/, '')
       .split(/\r\n|\r|\n/);
-    if (preparedCommit) {
+
+    if (preparedCommit.length && preparedCommit[0]) {
       if (context === 'subject') [message] = preparedCommit;
       else if (context === 'body' && preparedCommit.length > 1) {
         preparedCommit.shift();

--- a/questions.js
+++ b/questions.js
@@ -1,5 +1,6 @@
 const _ = require('lodash');
 const buildCommit = require('./buildCommit');
+const { existsSync, readFileSync } = require('fs');
 const log = require('./logger');
 
 const isNotWip = answers => answers.type.toLowerCase() !== 'wip';
@@ -16,6 +17,26 @@ const isValidateTicketNo = (value, config) => {
     return false;
   }
   return true;
+};
+
+const getPreparedCommit = context => {
+  let message = null;
+  if (existsSync('./.git/COMMIT_EDITMSG')) {
+    let preparedCommit = readFileSync('./.git/COMMIT_EDITMSG', 'utf-8');
+    preparedCommit = preparedCommit
+      .replace(/^#.*/gm, '')
+      .replace(/^\s*[\r\n]/gm, '')
+      .replace(/[\r\n]$/, '')
+      .split(/\r\n|\r|\n/);
+    if (preparedCommit) {
+      if (context === 'subject') message = preparedCommit[0];
+      else if (context === 'body' && preparedCommit.length > 1) {
+        preparedCommit.shift();
+        message = preparedCommit.join('|');
+      }
+    }
+  }
+  return message;
 };
 
 module.exports = {
@@ -110,6 +131,7 @@ module.exports = {
         type: 'input',
         name: 'subject',
         message: messages.subject,
+        default: getPreparedCommit('subject'),
         validate(value) {
           const limit = config.subjectLimit || 100;
           if (value.length > limit) {
@@ -127,6 +149,7 @@ module.exports = {
         type: 'input',
         name: 'body',
         message: messages.body,
+        default: getPreparedCommit('body'),
       },
       {
         type: 'input',

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -1,3 +1,5 @@
+/* eslint-disable nada/path-case */
+const fs = require('fs');
 const questions = require('../questions.js');
 
 describe('cz-customizable', () => {
@@ -62,6 +64,7 @@ describe('cz-customizable', () => {
     // question 5 - SUBJECT
     expect(getQuestion(5).name).toEqual('subject');
     expect(getQuestion(5).type).toEqual('input');
+    expect(getQuestion(5).default).toEqual(null);
     expect(getQuestion(5).message).toMatch(/IMPERATIVE tense description/);
     expect(getQuestion(5).filter('Subject')).toEqual('subject');
     expect(getQuestion(5).validate('bad subject that exceed limit for 6 characters')).toEqual('Exceed limit: 40');
@@ -70,6 +73,7 @@ describe('cz-customizable', () => {
     // question 6 - BODY
     expect(getQuestion(6).name).toEqual('body');
     expect(getQuestion(6).type).toEqual('input');
+    expect(getQuestion(6).default).toEqual(null);
 
     // question 7 - BREAKING CHANGE
     expect(getQuestion(7).name).toEqual('breaking');
@@ -258,6 +262,44 @@ describe('cz-customizable', () => {
         };
         expect(getQuestion(4).validate('12345')).toEqual(true);
       });
+    });
+  });
+
+  describe('commit already prepared', () => {
+    let existsSync;
+    let readFileSync;
+
+    beforeEach(() => {
+      config = {};
+      existsSync = spyOn(fs, 'existsSync');
+      readFileSync = spyOn(fs, 'readFileSync');
+    });
+
+    it('should ignore if there is no prepared commit file', () => {
+      existsSync.andReturn(false);
+      expect(getQuestion(5).default).toEqual(null);
+      expect(getQuestion(6).default).toEqual(null);
+    });
+
+    it('should ignore an empty prepared commit', () => {
+      existsSync.andReturn(true);
+      readFileSync.andReturn('');
+      expect(getQuestion(5).default).toEqual(null);
+      expect(getQuestion(6).default).toEqual(null);
+    });
+
+    it('should take a single line commit as the subject', () => {
+      existsSync.andReturn(true);
+      readFileSync.andReturn('my commit');
+      expect(getQuestion(5).default).toEqual('my commit');
+      expect(getQuestion(6).default).toEqual(null);
+    });
+
+    it('should split multi line commit between the subject and the body', () => {
+      existsSync.andReturn(true);
+      readFileSync.andReturn('my commit\nmessage\n\nis on several lines');
+      expect(getQuestion(5).default).toEqual('my commit');
+      expect(getQuestion(6).default).toEqual(`message|is on several lines`);
     });
   });
 });


### PR DESCRIPTION
There are two kind of people:

- Those who `git commit`
- Those who `git commit -m`

*cz-customizable* is for those who `git commit`

With this PR, *cz-customizable* is now for everybody!

When used as a git hook, using `git commit -m'my message'` was not making use of `'my message'`. **Now it does.**

This PR adds support for
- **single line** commit messages. The message is passed as the default answer for the `subject` question
- **multi line** commit messages. The first line is passed as the default answer for the `subject`question and the other lines are passed as the default answer for the `body` question

It is non invasive as it is passed as a `default` to enquirer. So the user can just press enter to use it or type another message if he wishes to.