### PR TITLE
fix: package url inside package.json after org creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "commit": "./standalone.js",
     "travis-deploy-once": "travis-deploy-once"
   },
-  "homepage": "https://github.com/leonardoanalista/cz-customizable",
+  "homepage": "https://github.com/leoforfree/cz-customizable",
   "repository": {
     "type": "git",
-    "url": "https://github.com/leonardoanalista/cz-customizable.git"
+    "url": "https://github.com/leoforfree/cz-customizable.git"
   },
   "author": "Leonardo Correa <leonardoanalista@gmail.com>",
   "contributors": [


### PR DESCRIPTION
I forgot to update the package url with the new organization name