### PR TITLE
fix: all prefixes excluded from subject placeholder

### DIFF
--- a/buildCommit.js
+++ b/buildCommit.js
@@ -1,9 +1,8 @@
 const _ = require('lodash');
 const wrap = require('word-wrap');
+const defaults = require('./defaults');
 
-const defaultSubjectSeparator = ': ';
 const defaultMaxLineWidth = 100;
-const defaultBreaklineChar = '|';
 
 const addTicketNumber = (ticketNumber, config) => {
   if (!ticketNumber) {
@@ -16,7 +15,7 @@ const addTicketNumber = (ticketNumber, config) => {
 };
 
 const addScope = (scope, config) => {
-  const separator = _.get(config, 'subjectSeparator', defaultSubjectSeparator);
+  const separator = _.get(config, 'subjectSeparator', defaults.subjectSeparator);
 
   if (!scope) return separator; // it could be type === WIP. So there is no scope
 
@@ -32,7 +31,7 @@ const addType = (type, config) => {
   return _.trim(`${prefix}${type}${suffix}`);
 };
 
-const addBreaklinesIfNeeded = (value, breaklineChar = defaultBreaklineChar) =>
+const addBreaklinesIfNeeded = (value, breaklineChar = defaults.breaklineChar) =>
   value
     .split(breaklineChar)
     .join('\n')

--- a/defaults.js
+++ b/defaults.js
@@ -1,0 +1,4 @@
+module.exports = {
+  subjectSeparator: ': ',
+  breaklineChar: '|',
+};

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -270,7 +270,10 @@ describe('cz-customizable', () => {
     let readFileSync;
 
     beforeEach(() => {
-      config = {};
+      config = {
+        ticketNumberPrefix: 'TICKET-',
+        ticketNumberRegExp: '\\d{1,5}',
+      };
       existsSync = spyOn(fs, 'existsSync');
       readFileSync = spyOn(fs, 'readFileSync');
     });
@@ -290,7 +293,7 @@ describe('cz-customizable', () => {
 
     it('should take a single line commit as the subject', () => {
       existsSync.andReturn(true);
-      readFileSync.andReturn('my commit');
+      readFileSync.andReturn('type(scope): TICKET-123 my commit');
       expect(getQuestion(5).default).toEqual('my commit');
       expect(getQuestion(6).default).toEqual(null);
     });


### PR DESCRIPTION
This PR fixes subject placeholder/default value from previous commit message.

**As it was before**
Previous message: type(scope): TICKET-123 Subject text
Placeholder: type(scope): TICKET-123 Subject text
Commit message: type(scope): TICKET-124 type(scope): TICKET-123 Subject text

**As it is now**
Previous message: type(scope): TICKET-123 Subject text
Placeholder: Subject text
Commit message:  type(scope): TICKET-124 Subject text