### PR TITLE
fix: only use prepared commit message if run as hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,12 +46,14 @@ const readConfigFile = () => {
 };
 
 module.exports = {
-  prompter(cz, commit) {
+  prompter(cz, commit, isStandalone = false) {
     const config = readConfigFile();
     config.subjectLimit = config.subjectLimit || 100;
     log.info('All lines except first will be wrapped after 100 characters.');
 
-    const questions = require('./questions').getQuestions(config, cz);
+    const isHook = process.argv.includes('--hook');
+
+    const questions = require('./questions').getQuestions(config, cz, isStandalone || isHook);
 
     cz.prompt(questions).then(answers => {
       if (answers.confirmCommit === 'edit') {

--- a/questions.js
+++ b/questions.js
@@ -41,7 +41,7 @@ const getPreparedCommit = context => {
 };
 
 module.exports = {
-  getQuestions(config, cz) {
+  getQuestions(config, cz, isStandaloneOrHook = false) {
     // normalize config optional options
     const scopeOverrides = config.scopeOverrides || {};
     const messages = config.messages || {};
@@ -132,7 +132,7 @@ module.exports = {
         type: 'input',
         name: 'subject',
         message: messages.subject,
-        default: getPreparedCommit('subject'),
+        default: isStandaloneOrHook ? getPreparedCommit('subject') : null,
         validate(value) {
           const limit = config.subjectLimit || 100;
           if (value.length > limit) {
@@ -150,7 +150,7 @@ module.exports = {
         type: 'input',
         name: 'body',
         message: messages.body,
-        default: getPreparedCommit('body'),
+        default: isStandaloneOrHook ? getPreparedCommit('body') : null,
       },
       {
         type: 'input',

--- a/spec/questionsSpec.js
+++ b/spec/questionsSpec.js
@@ -13,7 +13,8 @@ describe('cz-customizable', () => {
     Separator: jasmine.createSpy(),
   };
 
-  const getQuestion = number => questions.getQuestions(config, mockedCz)[number - 1];
+  const getQuestion = (number, isStandaloneOrHook = false) =>
+    questions.getQuestions(config, mockedCz, isStandaloneOrHook)[number - 1];
 
   it('should array of questions be returned', () => {
     config = {
@@ -277,29 +278,29 @@ describe('cz-customizable', () => {
 
     it('should ignore if there is no prepared commit file', () => {
       existsSync.andReturn(false);
-      expect(getQuestion(5).default).toEqual(null);
-      expect(getQuestion(6).default).toEqual(null);
+      expect(getQuestion(5, true).default).toEqual(null);
+      expect(getQuestion(6, true).default).toEqual(null);
     });
 
     it('should ignore an empty prepared commit', () => {
       existsSync.andReturn(true);
       readFileSync.andReturn('');
-      expect(getQuestion(5).default).toEqual(null);
-      expect(getQuestion(6).default).toEqual(null);
+      expect(getQuestion(5, true).default).toEqual(null);
+      expect(getQuestion(6, true).default).toEqual(null);
     });
 
     it('should take a single line commit as the subject', () => {
       existsSync.andReturn(true);
       readFileSync.andReturn('my commit');
-      expect(getQuestion(5).default).toEqual('my commit');
-      expect(getQuestion(6).default).toEqual(null);
+      expect(getQuestion(5, true).default).toEqual('my commit');
+      expect(getQuestion(6, true).default).toEqual(null);
     });
 
     it('should split multi line commit between the subject and the body', () => {
       existsSync.andReturn(true);
       readFileSync.andReturn('my commit\nmessage\n\nis on several lines');
-      expect(getQuestion(5).default).toEqual('my commit');
-      expect(getQuestion(6).default).toEqual(`message|is on several lines`);
+      expect(getQuestion(5, true).default).toEqual('my commit');
+      expect(getQuestion(6, true).default).toEqual(`message|is on several lines`);
     });
   });
 });

--- a/standalone.js
+++ b/standalone.js
@@ -16,4 +16,4 @@ const commit = commitMessage => {
   }
 };
 
-app.prompter(inquirer, commit);
+app.prompter(inquirer, commit, true);


### PR DESCRIPTION
Problem: The prepared commit message feature added in #122 sometimes sets a default from the `COMMIT_EDITMSG` file when I run `git cz`. As this message is from a previous commit it is annoying to see it there. It's not a huge problem in the subject as I will always overwrite a new subject, but in the body when I hit enter to leave the body empty it fills it with the default.

Solution: Only set the default when cz-customizable has been run as a hook or in standalone mode

I couldn't think of a better way to detect whether to turn this feature on but I think this a safe solution and won't break it for anyone that is reliant on it