### PR TITLE
feat: Allow to skip scope question

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Here are the options you can set in your `.cz-config.js`:
 * **allowCustomScopes**: {boolean, default false}: adds the option `custom` to scope selection so you can still type a scope if you need.
 * **allowBreakingChanges**: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix'].
 * **skipQuestions**: {Array of Strings: default none}. List of questions you want to skip. Eg.: ['body', 'footer'].
+* **skipEmptyScopes**: {boolean, default false}: If a chosen type has no scopes declared, skip the scope question
 * **appendBranchNameToCommitMessage**: If you use `cz-customizable` with `cz-customizable-ghooks`, you can get the branch name automatically appended to the commit message. This is done by a commit hook on `cz-customizable-ghooks`. This option has been added on `cz-customizable-ghooks`, v1.3.0. Default value is `true`.
 * **ticketNumberPrefix**: {string, default 'ISSUES CLOSED:'}: Set custom prefix for footer ticker number.
 * **breakingPrefix**: {string, default 'BREAKING CHANGE:'}: Set a custom prefix for the breaking change block in commit messages.

--- a/questions.js
+++ b/questions.js
@@ -46,6 +46,7 @@ module.exports = {
     const scopeOverrides = config.scopeOverrides || {};
     const messages = config.messages || {};
     const skipQuestions = config.skipQuestions || [];
+    const skipEmptyScopes = config.skipEmptyScopes || false;
 
     messages.type = messages.type || "Select the type of change that you're committing:";
     messages.scope = messages.scope || '\nDenote the SCOPE of this change (optional):';
@@ -103,7 +104,7 @@ module.exports = {
           if (!hasScope) {
             // TODO: Fix when possible
             // eslint-disable-next-line no-param-reassign
-            answers.scope = 'custom';
+            answers.scope = skipEmptyScopes ? '' : 'custom';
             return false;
           }
           return isNotWip(answers);


### PR DESCRIPTION
This adds a simple boolean to the config, so that the question for scopes can be skipped if no scopes are defined. This is useful for example if you use scope overrides to add scopes only to a subset of types.