### PR TITLE
bugfix: read COMMIT_EDITMSG from project root

### DIFF
--- a/questions.js
+++ b/questions.js
@@ -19,10 +19,23 @@ const isValidateTicketNo = (value, config) => {
   return true;
 };
 
+const getGitMsgFile = () => {
+  let root = './'
+  let filePath = '.git/COMMIT_EDITMSG'
+  try {
+    const buffer = execSync('git rev-parse --show-toplevel')
+    root = buffer.toString().replace('\n', '') + '/'
+  } catch (error) {
+    // emtpy
+  }
+  return root + filePath
+}
+
 const getPreparedCommit = context => {
   let message = null;
-  if (fs.existsSync('./.git/COMMIT_EDITMSG')) {
-    let preparedCommit = fs.readFileSync('./.git/COMMIT_EDITMSG', 'utf-8');
+  const filepath = getGitMsgFile()
+  if (fs.existsSync(filepath)) {
+    let preparedCommit = fs.readFileSync(filepath, 'utf-8');
     preparedCommit = preparedCommit
       .replace(/^#.*/gm, '')
       .replace(/^\s*[\r\n]/gm, '')


### PR DESCRIPTION
husky v6：
husky config may not in project root (https://typicode.github.io/husky/#/?id=monorepo)
should read COMMIT_EDITMSG from project root