### PR TITLE
Fix custom scopes - Add askAnswered to true

### DIFF
--- a/lib/questions.js
+++ b/lib/questions.js
@@ -116,6 +116,7 @@ module.exports = {
       {
         type: 'input',
         name: 'scope',
+        askAnswered: true,
         message: messages.customScope,
         when(answers) {
           return answers.scope === 'custom';


### PR DESCRIPTION
Fix custom scopes
  {
     type: 'input',
     name: 'scope',
     askAnswered: true,
     message: messages.customScope,
     ...
  }