### PR TITLE
fix: fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If everything is correct, you should see commit questions like the image above.
 
 ## Option 2 - cz-customizable in standalone mode
 
-Use `cz-customizable` without `commitzen`.
+Use `cz-customizable` without `commitizen`.
 
 * npm install `npm install cz-customizable --save-dev`
 * add a new script to your `package.json`:


### PR DESCRIPTION
Hey,

There is a tiny typo in the README file. `commitzen` should be `commitizen`.

Thanks for your great library!