### PR TITLE
Fix str.match is not a function error

### DIFF
--- a/lib/build-commit.js
+++ b/lib/build-commit.js
@@ -79,7 +79,7 @@ module.exports = (answers, config) => {
     addSubject(answers.subject.slice(0, config.subjectLimit));
 
   // Wrap these lines at 100 characters
-  let body = wrap(answers.body, wrapOptions) || '';
+  let body = (answers.body ? wrap(answers.body, wrapOptions) : '') || '';
   body = addBreaklinesIfNeeded(body, config.breaklineChar);
 
   const breaking = wrap(answers.breaking, wrapOptions);


### PR DESCRIPTION
Fixes https://github.com/leoforfree/cz-customizable/issues/208 based on debugging in the original issue.