### PR TITLE
fix: able multi-line commit on Windows (#211)

### DIFF
--- a/standalone.js
+++ b/standalone.js
@@ -11,9 +11,9 @@ log.info('cz-customizable standalone version');
 const commit = (commitMessage) => {
   try {
     execSync(
-      `git commit${commitMessage
+      `git commit ${commitMessage
         .split('\n')
-        .map((n) => ` -m "${n}"`)
+        .map((n) => `-m "${n}"`)
         .join(' ')}`,
       { stdio: [0, 1, 2] },
     );

--- a/standalone.js
+++ b/standalone.js
@@ -10,7 +10,13 @@ log.info('cz-customizable standalone version');
 
 const commit = (commitMessage) => {
   try {
-    execSync(`git commit -m "${commitMessage}"`, { stdio: [0, 1, 2] });
+    execSync(
+      `git commit${commitMessage
+        .split('\n')
+        .map((n) => ` -m "${n}"`)
+        .join(' ')}`,
+      { stdio: [0, 1, 2] },
+    );
   } catch (error) {
     log.error('>>> ERROR', error.error);
   }


### PR DESCRIPTION
As #133 and #211 said, at least Windows 10 cannot commit when there are many lines. I have fixed it for standalone mode.