### PR TITLE
fix: incorrect body split

### DIFF
--- a/lib/build-commit.js
+++ b/lib/build-commit.js
@@ -79,8 +79,14 @@ module.exports = (answers, config) => {
     addSubject(answers.subject.slice(0, config.subjectLimit));
 
   // Wrap these lines at 100 characters
-  let body = wrap(answers.body, wrapOptions) || '';
-  body = addBreaklinesIfNeeded(body, config.breaklineChar);
+  let body;
+  if (answers.body) {
+    body = answers.body;
+    body = addBreaklinesIfNeeded(body, config.breaklineChar);
+    body = wrap(body, wrapOptions);
+  } else {
+    body = '';
+  }
 
   const breaking = wrap(answers.breaking, wrapOptions);
   const footer = wrap(answers.footer, wrapOptions);


### PR DESCRIPTION
Add breaklines before wrap body

For example:
```
* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar|* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar 
```
### Before
Wrap first, split line at 100 characters
```
* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar|* 
foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar 
```
Then split with "|":
```
* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar
* 
foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar 
```
### Now
The output is correct:
```
* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar
* foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar foobar 