### PR TITLE
feat(additionalQuestion): support additional questions for commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ Here are the options you can set in your `.cz-config.js`:
     ]
   }
   ```
+* **additionalQuestions**:{Array of object} To ask additional question. Answers will be appended to body part. All keys of object are required.
+  ```
+   additionalQuestions: [
+    {
+      type: 'input',
+      name: 'time',
+      message: 'Time spent (i.e. 1h 15m) (optional):\n',
+      mapping: "#time"
+    },
+    {
+      type: 'input',
+      name: 'comment',
+      message: 'Jira comment (optional):\n',
+      mapping: "#comment"
+    }
+  ],
+  ```
 * **allowCustomScopes**: {boolean, default false}: adds the option `custom` to scope selection so you can still type a scope if you need.
 * **allowBreakingChanges**: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix'].
 * **skipQuestions**: {Array of Strings: default none}. List of questions you want to skip. Eg.: ['body', 'footer'].

--- a/lib/build-commit.js
+++ b/lib/build-commit.js
@@ -98,6 +98,12 @@ module.exports = (answers, config) => {
     body = '';
   }
 
+  (config.additionalQuestions || []).forEach((question) => {
+    if (answers[question.name]) {
+      body += `\n${question.mapping} ${answers[question.name]}`;
+    }
+  });
+
   const breaking = wrap(answers.breaking, wrapOptions);
   const footer = wrap(answers.footer, wrapOptions);
 

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -160,6 +160,7 @@ module.exports = {
         message: messages.body,
         default: config.usePreparedCommit && getPreparedCommit('body'),
       },
+      ...(config.additionalQuestions || []),
       {
         type: 'input',
         name: 'breaking',


### PR DESCRIPTION
You can add n number of additional questions for commit.
And append  answers to the body of commit message.
These question can help you to create smart-commit and pass information to third party like jira (with help of mapping)