### PR TITLE
fix(skipQuestions): Enable successful commit when 'confirmCommit' question is skipped

### DIFF
--- a/__tests__/cz-customizable.test.js
+++ b/__tests__/cz-customizable.test.js
@@ -401,4 +401,27 @@ describe('cz-customizable', () => {
     czModule.prompter(mockCz, commit);
     expect(commit).toHaveBeenCalledWith('feat(myScope): [TICKET-1234] create a new cool feature');
   });
+
+  it('should call commit() function when confirmCommit message is skipped and no confirmCommit answer is present', () => {
+    readConfigFile.mockReturnValue({
+      types: [{ value: 'feat', name: 'feat: my feat' }],
+      scopes: [{ name: 'myScope' }],
+      skipQuestions: ['confirmCommit'],
+      scopeOverrides: {
+        fix: [{ name: 'fixOverride' }],
+      },
+      allowCustomScopes: true,
+      allowBreakingChanges: ['feat'],
+      usePreparedCommit: true,
+    });
+
+    const answers = {
+      type: 'feat',
+      subject: 'create a new cool feature',
+    };
+
+    const mockCz = getMockedCz(answers);
+    czModule.prompter(mockCz, commit);
+    expect(commit).toHaveBeenCalledWith('feat: create a new cool feature');
+  });
 });

--- a/index.js
+++ b/index.js
@@ -18,6 +18,8 @@ module.exports = {
 
     const questions = require('./lib/questions').getQuestions(config, cz);
 
+    const skipQuestions = config.skipQuestions || [];
+
     cz.prompt(questions).then((answers) => {
       if (answers.confirmCommit === 'edit') {
         temp.open(null, (err, info) => {
@@ -38,7 +40,7 @@ module.exports = {
             });
           }
         });
-      } else if (answers.confirmCommit === 'yes' || config.skipQuestions.includes('confirmCommit')) {
+      } else if (answers.confirmCommit === 'yes' || skipQuestions.includes('confirmCommit')) {
         commit(buildCommit(answers, config));
       } else {
         log.info('Commit has been canceled.');

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = {
             });
           }
         });
-      } else if (answers.confirmCommit === 'yes') {
+      } else if (answers.confirmCommit === 'yes' || config.skipQuestions.includes('confirmCommit')) {
         commit(buildCommit(answers, config));
       } else {
         log.info('Commit has been canceled.');


### PR DESCRIPTION
As of now the 'confirmCommit' question cannot be skipped (As of my knowledge, maybe i am missing something). Currently a user is able to skip the question but this will always result in the 'Commit has been canceled.' message.

This PR enables the skipping of the 'confirmCommit' message with a successfully built commit.