### PR TITLE
Feature/exclude answer

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,9 +146,14 @@ Here are the options you can set in your `.cz-config.js`:
     ]
   }
   ```
-* **additionalQuestions**:{Array of object} To ask additional question. Answers will be appended to body part. All keys of object are required.
-  ```
-   additionalQuestions: [
+* **additionalQuestions**: {Array<Object>, default `[]`}: Specify extra prompts whose answers will be appended to the commit message body. Each object **must** include:
+  - `type` (`string`): Prompt type for [Inquirer.js](https://github.com/SBoudrias/Inquirer.js) (e.g. `input`, `confirm`)
+  - `name` (`string`): Key under which the answer is stored
+  - `message` (`string`): Text shown to the user when prompting
+  - `mapping` (`string`): Label to prepend to the answer in the commit body
+  - `excludeFromCommitMsg` (`() => boolean`, _optional_): If it returns `true`, this answer is omitted from the commit body  
+  ```js
+  additionalQuestions: [
     {
       type: 'input',
       name: 'time',
@@ -159,9 +164,10 @@ Here are the options you can set in your `.cz-config.js`:
       type: 'input',
       name: 'comment',
       message: 'Jira comment (optional):\n',
-      mapping: "#comment"
+      mapping: "#comment:",
+      excludeFromCommitMsg: () => true
     }
-  ],
+  ]
   ```
 * **allowCustomScopes**: {boolean, default false}: adds the option `custom` to scope selection so you can still type a scope if you need.
 * **allowBreakingChanges**: {Array of Strings: default none}. List of commit types you would like to the question `breaking change` prompted. Eg.: ['feat', 'fix'].

--- a/__tests__/build-commit.test.js
+++ b/__tests__/build-commit.test.js
@@ -177,4 +177,50 @@ line 2`;
     // eslint-disable-next-line prettier/prettier, no-useless-escape
     expect(buildCommit(altAnswers, {})).toEqual('feat(app): th\\\"is i\'s a n\\`ew \\\\$ f\\<ea\\>ture \\&');
   });
+
+  describe('additionalQuestions', () => {
+    const baseAnswers = {
+      type: 'feat',
+      scope: 'app',
+      subject: 'this is a new feature',
+    };
+
+    it('should include all additional questions in the commit body', () => {
+      const answersWithAQ = {
+        ...baseAnswers,
+        epic: 'EPIC-124',
+        issue: 'ISSUE-456',
+      };
+      const options = {
+        additionalQuestions: [
+          { name: 'epic', mapping: 'Epic Link:' },
+          { name: 'issue', mapping: 'Issue:' },
+        ],
+      };
+
+      expect(buildCommit(answersWithAQ, options)).toEqual(
+        'feat(app): this is a new feature\n\n\nEpic Link: EPIC-124\nIssue: ISSUE-456',
+      );
+    });
+
+    it('should exclude questions when excludeFromCommitMsg returns true', () => {
+      const answersWithAQ = {
+        ...baseAnswers,
+        epic: 'EPIC-124',
+        issue: 'ISSUE-456',
+      };
+      const options = {
+        additionalQuestions: [
+          { name: 'epic', mapping: 'Epic Link:' },
+          {
+            name: 'issue',
+            mapping: 'Issue:',
+            excludeFromCommitMsg: () => true,
+          },
+        ],
+      };
+
+      expect(buildCommit(answersWithAQ, options)).toEqual('feat(app): this is a new feature\n\n\nEpic Link: EPIC-124');
+    });
+  });
 });

--- a/lib/build-commit.js
+++ b/lib/build-commit.js
@@ -98,9 +98,12 @@ module.exports = (answers, config) => {
     body = '';
   }
 
-  (config.additionalQuestions || []).forEach((question) => {
-    if (answers[question.name]) {
-      body += `\n${question.mapping} ${answers[question.name]}`;
+  (config.additionalQuestions || []).forEach(({ excludeFromCommitMsg, name, mapping }) => {
+    // `excludeFromCommitMsg` is a function that determines whether a specific question's answer
+    // should be excluded from the commit message. It takes the `answers` object as input and
+    // returns a boolean value. If it returns `true`, the question's answer is excluded.
+    if (answers[name] && !(excludeFromCommitMsg && excludeFromCommitMsg(answers))) {
+      body += `\n${mapping} ${answers[name]}`;
     }
   });
 


### PR DESCRIPTION
# feat: add `excludeFromCommitMsg` option for additionalQuestions

## Description

This PR introduces a new `excludeFromCommitMsg` predicate on each entry in `additionalQuestions`. When defined, it allows users to conditionally omit certain answers from the generated commit message body based on the full set of answers provided.

---

## Motivation and Context

By default, all answers to `additionalQuestions` are appended to the commit body. In some workflows, you may want to collect supplemental information (e.g., an internal ticket, link to a spec, or QA note) in the prompt but **not** include it in the final Git commit message. The `excludeFromCommitMsg` callback lets you exclude those fields at commit-generation time:

```js
additionalQuestions: [
  {
    name: 'internalNotes',
    mapping: 'Notes:',
    // only include if the user explicitly opts in
    excludeFromCommitMsg: answers => !answers.includeInternalNotes,
  }
]
```

## Changes
### API

Added optional excludeFromCommitMsg?: (answers) => boolean to each additionalQuestions entry.

### Behavior

* For each question with an excludeFromCommitMsg function, we now call it with the full answers object.
* If it returns true, that particular mapping + answer pair is not appended to the commit message body.

### Tests

Added two new unit tests covering both inclusion and exclusion paths.

### Docs

Updated README to document the excludeFromCommitMsg option and include a usage example.