### PR TITLE
fix: fixed reading home .cz-config.js

### DIFF
--- a/lib/read-config-file.js
+++ b/lib/read-config-file.js
@@ -6,14 +6,13 @@ const log = require('./logger');
 
 const readConfigFile = (CZ_CONFIG_NAME = '.cz-config.js') => {
   // First try to find the .cz-config.js config file
-  // It seems like find-config still locates config files in the home directory despite of the home:false prop.
-  const czConfig = findConfig.require(CZ_CONFIG_NAME, { home: false });
+  const czConfig = findConfig.require(CZ_CONFIG_NAME, { home: true });
 
   if (czConfig) {
     return czConfig;
   }
 
-  const czConfigJSON = findConfig.require(`${path.parse(CZ_CONFIG_NAME).name}.json`, { home: false })
+  const czConfigJSON = findConfig.require(`${path.parse(CZ_CONFIG_NAME).name}.json`, { home: true })
 
   if (czConfigJSON) {
     return czConfigJSON


### PR DESCRIPTION
this PR should fix `Unable to find a configuration file. Please refer to documentation to learn how to set up: https://github.com/leonardoanalista/cz-customizable#steps "` when the configuration file is in `$HOME`